### PR TITLE
Return pointer of custom error

### DIFF
--- a/client/accounts_test.go
+++ b/client/accounts_test.go
@@ -77,8 +77,8 @@ func TestGetModules(t *testing.T) {
 
 		c := NewAptosClient(srv.URL)
 		_, err := c.GetAccountModules(ctx, mockAddr)
-		err2, ok := errors.Unwrap(err).(Error)
-		assert.Equal(t, true, ok)
-		assert.Equal(t, true, err2.IsAccountNotFound())
+		var e *Error
+		assert.Equal(t, true, errors.As(err, &e))
+		assert.Equal(t, true, e.IsErrorCode(ErrAccountNotFound))
 	})
 }

--- a/client/client.go
+++ b/client/client.go
@@ -143,7 +143,7 @@ func request(ctx context.Context, method, endpoint string, reqBody, resp interfa
 		var err Error
 		if json.Unmarshal(rspBody, &err) == nil {
 			err.StatusCode = rsp.StatusCode
-			return err
+			return &err
 		}
 		return fmt.Errorf("response(%d): %s", rsp.StatusCode, string(rspBody))
 	}

--- a/client/error.go
+++ b/client/error.go
@@ -15,18 +15,10 @@ type Error struct {
 	VMErrorCode int    `json:"vm_error_code"`
 }
 
-func (e Error) Error() string {
+func (e *Error) Error() string {
 	return fmt.Sprintf("%s: %s", e.ErrorCode, e.Message)
 }
 
-func (e Error) IsTableItemNotFound() bool {
-	return e.ErrorCode == ErrTableItemNotFound
-}
-
-func (e Error) IsAccountNotFound() bool {
-	return e.ErrorCode == ErrAccountNotFound
-}
-
-func (e Error) IsModuleNotFound() bool {
-	return e.ErrorCode == ErrModuleNotFound
+func (e *Error) IsErrorCode(code string) bool {
+	return e.ErrorCode == code
 }

--- a/client/token.go
+++ b/client/token.go
@@ -472,10 +472,9 @@ func (impl *TokenClientImpl) ListAccountTokens(ctx context.Context, owner models
 			if !tokenIDs[data.ID] {
 				token, err := impl.GetToken(ctx, owner, data.ID)
 				if err != nil {
-					if err, ok := errors.Unwrap(err).(Error); ok {
-						if err.IsTableItemNotFound() {
-							continue
-						}
+					var e *Error
+					if ok := errors.As(err, &e); ok && e.IsErrorCode(ErrTableItemNotFound) {
+						continue
 					}
 					return nil, fmt.Errorf("GetToken error: %v", err)
 				}


### PR DESCRIPTION
- Return pointer of error in order to make every returned errors distinct even if the content are identical. Ref: https://stackoverflow.com/questions/50333428/custom-errors-in-golang-and-pointer-receivers
- `errors.As` for wrapped errors should be preferable to type assertion
 
