### PR TITLE
Set authenticator for tx without signature verify

### DIFF
--- a/examples/transactions/main.go
+++ b/examples/transactions/main.go
@@ -298,7 +298,7 @@ func replaceAuthKey() {
 	err = tx.SetAuthenticator(models.TransactionAuthenticatorEd25519{
 		PublicKey: priv.Public().(ed25519.PublicKey),
 		Signature: signature,
-	}).Error()
+	}, true).Error()
 	if err != nil {
 		panic(err)
 	}
@@ -365,7 +365,7 @@ func transferTxMultiED25519() {
 		Threshold:  1,
 		Signatures: []models.Signature{signature},
 		Bitmap:     [4]byte{0x40, 0, 0, 0},
-	}).Error()
+	}, true).Error()
 	if err != nil {
 		panic(err)
 	}
@@ -446,7 +446,7 @@ func createAccountTx(keyNum int) (authKey [32]byte, seeds []string) {
 	err = tx.SetAuthenticator(models.TransactionAuthenticatorEd25519{
 		PublicKey: faucetAdminPriv.Public().(ed25519.PublicKey),
 		Signature: signature,
-	}).Error()
+	}, true).Error()
 	if err != nil {
 		panic(err)
 	}
@@ -582,7 +582,7 @@ func invokeMultiAgent() {
 				Bitmap:     [4]byte{0x40, 0, 0, 0},
 			},
 		},
-	}).Error()
+	}, true).Error()
 	if err != nil {
 		panic(err)
 	}
@@ -720,7 +720,7 @@ func invokeMultiAgentRotateKey() {
 		Threshold:  1,
 		Signatures: []models.Signature{signature},
 		Bitmap:     [4]byte{0x40, 0, 0, 0},
-	}).Error()
+	}, true).Error()
 	if err != nil {
 		panic(err)
 	}
@@ -793,7 +793,7 @@ func invokeScriptPayload() {
 	err = tx.SetAuthenticator(models.TransactionAuthenticatorEd25519{
 		PublicKey: priv.Public().(ed25519.PublicKey),
 		Signature: signature,
-	}).Error()
+	}, true).Error()
 	if err != nil {
 		panic(err)
 	}
@@ -895,7 +895,7 @@ func invokeMultiAgentScriptPayload(scriptName string, typeArgs []models.TypeTag,
 				Bitmap:     [4]byte{0x40, 0, 0, 0},
 			},
 		},
-	}).Error()
+	}, true).Error()
 	if err != nil {
 		panic(err)
 	}
@@ -974,7 +974,7 @@ func createWeightAccountTx() (authKey [32]byte, seeds []string) {
 	err = tx.SetAuthenticator(models.TransactionAuthenticatorEd25519{
 		PublicKey: faucetAdminPriv.Public().(ed25519.PublicKey),
 		Signature: signature,
-	}).Error()
+	}, true).Error()
 	if err != nil {
 		panic(err)
 	}
@@ -1045,7 +1045,7 @@ func transferTxWeightedMultiED25519() {
 		Threshold:  2,
 		Signatures: []models.Signature{signature, signature},
 		Bitmap:     [4]byte{0x30, 0, 0, 0},
-	}).Error()
+	}, true).Error()
 	if err != nil {
 		panic(err)
 	}

--- a/models/authenticator.go
+++ b/models/authenticator.go
@@ -48,7 +48,7 @@ func (s *SingleSigner) Sign(tx *Transaction) *Transaction {
 	return tx.SetAuthenticator(TransactionAuthenticatorEd25519{
 		PublicKey: s.PublicKey,
 		Signature: signature,
-	})
+	}, true)
 }
 
 type PublicKey = ed25519.PublicKey

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -200,7 +200,7 @@ func (t *Transaction) SetPayload(payload TransactionPayload) *Transaction {
 	return t
 }
 
-func (t *Transaction) SetAuthenticator(txAuth TransactionAuthenticator) *Transaction {
+func (t *Transaction) SetAuthenticator(txAuth TransactionAuthenticator, verify bool) *Transaction {
 	if t.hasError() {
 		return t
 	}
@@ -214,22 +214,26 @@ func (t *Transaction) SetAuthenticator(txAuth TransactionAuthenticator) *Transac
 
 	switch txAuth := txAuth.(type) {
 	case TransactionAuthenticatorEd25519:
-		if !ed25519.Verify(txAuth.PublicKey, t.signingMessage, txAuth.Signature) {
+		if verify && !ed25519.Verify(txAuth.PublicKey, t.signingMessage, txAuth.Signature) {
 			t.err = errors.New("ed25519.Verify failed")
 			return t
 		}
 		t.Authenticator = txAuth
 	case TransactionAuthenticatorMultiEd25519:
-		if err := t.validateMultiEd25519(txAuth); err != nil {
-			t.err = err
-			return t
+		if verify {
+			if err := t.validateMultiEd25519(txAuth); err != nil {
+				t.err = err
+				return t
+			}
 		}
 
 		t.Authenticator = txAuth.SetBytes()
 	case TransactionAuthenticatorMultiAgent:
-		if err := t.validateMultiAgent(txAuth); err != nil {
-			t.err = err
-			return t
+		if verify {
+			if err := t.validateMultiAgent(txAuth); err != nil {
+				t.err = err
+				return t
+			}
 		}
 
 		switch sender := txAuth.Sender.(type) {


### PR DESCRIPTION
Simulated transactions are supposed to have zero-padded signature, so allow user to add authenticator to tx without verifying.
API document: https://fullnode.devnet.aptoslabs.com/v1/spec#/operations/simulate_transaction