### PR TITLE
Fix issue#37

### DIFF
--- a/models/account_address.go
+++ b/models/account_address.go
@@ -9,16 +9,21 @@ import (
 type AccountAddress [32]byte
 
 func (addr AccountAddress) PrefixZeroTrimmedHex() string {
+	/* According to Aptos docs:
+	 * https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/doc/account.md
+	 * The system reserved addresses is 0x1 / 0x2 / 0x3 / 0x4 / 0x5 / 0x6 / 0x7 / 0x8 / 0x9 / 0xa
+	 * These addreeses would be return as string 0x1 / 0x2 / 0x3 / 0x4 / 0x5 / 0x6 / 0x7 / 0x8 / 0x9 / 0xa
+	 * Other addresses would be return as string 0x + hex string
+	 */
 	nonZeroIndex := 0
-	for nonZeroIndex < 32 && addr[nonZeroIndex] == 0 {
+	for nonZeroIndex < 31 && addr[nonZeroIndex] == 0 {
 		nonZeroIndex++
 	}
-	if nonZeroIndex == 32 {
-		return "0x0"
+	if nonZeroIndex == 31 {
+		return fmt.Sprintf("0x%x", addr[31])
 	}
 
-	hex := hex.EncodeToString(addr[nonZeroIndex:])
-	return "0x" + strings.TrimPrefix(hex, "0")
+	return "0x" + hex.EncodeToString(addr[:])
 }
 
 func HexToAccountAddress(addr string) (AccountAddress, error) {

--- a/models/account_address_test.go
+++ b/models/account_address_test.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrefixZeroTrimmedHex(t *testing.T) {
+	t.Run("AptosReservedAddresses", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			aptosReservedAddr := fmt.Sprintf("0x%v", i)
+			addr, err := HexToAccountAddress(aptosReservedAddr)
+			assert.NoError(t, err)
+			assert.Equal(t, aptosReservedAddr, addr.PrefixZeroTrimmedHex())
+		}
+
+		aptosReservedAddr := "0xa"
+		addr, err := HexToAccountAddress(aptosReservedAddr)
+		assert.NoError(t, err)
+		assert.Equal(t, aptosReservedAddr, addr.PrefixZeroTrimmedHex())
+	})
+
+	t.Run("address", func(t *testing.T) {
+		addr := "0x1111111111111111111111111111111111111111111111111111111111111111"
+		accountAddr, err := HexToAccountAddress(addr)
+		assert.NoError(t, err)
+
+		assert.Equal(t, addr, accountAddr.PrefixZeroTrimmedHex())
+	})
+
+	t.Run("addressWithZeroAfter0xPrefix", func(t *testing.T) {
+		addr := "0x0111111111111111111111111111111111111111111111111111111111111111"
+		accountAddr, err := HexToAccountAddress(addr)
+		assert.NoError(t, err)
+
+		assert.Equal(t, addr, accountAddr.PrefixZeroTrimmedHex())
+	})
+}


### PR DESCRIPTION
[Issue#37](https://github.com/portto/aptos-go-sdk/issues/37)

According to Aptos docs:
https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/doc/account.md
The system reserved addresses is 0x1 / 0x2 / 0x3 / 0x4 / 0x5 / 0x6 / 0x7 / 0x8 / 0x9 / 0xa
These addreeses would be return as string 0x1 / 0x2 / 0x3 / 0x4 / 0x5 / 0x6 / 0x7 / 0x8 / 0x9 / 0xa
Other addresses would be return as string 0x + hex string